### PR TITLE
Download packages over a (more) secure connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@ xmpp-opam
 =========
 
 OPAM repository for xmpp development
+
+Add this to opam securely[1] with:
+
+`opam repo add xmpp-dev https://github.com/hannesm/xmpp-opam.git`
+
+[1] Assuming your X509 trust roots don't attack you

--- a/packages/astring/astring.0.0.1/url
+++ b/packages/astring/astring.0.0.1/url
@@ -1,1 +1,1 @@
-git: "http://erratique.ch/repos/astring.git"
+git: "https://github.com/dbuenzli/astring.git"

--- a/packages/erm_xml/erm_xml.0.3.1/url
+++ b/packages/erm_xml/erm_xml.0.3.1/url
@@ -1,1 +1,1 @@
-git: "git://github.com/hannesm/xml.git"
+git: "https://github.com/hannesm/xml.git"

--- a/packages/erm_xmpp/erm_xmpp.0.3/url
+++ b/packages/erm_xmpp/erm_xmpp.0.3/url
@@ -1,1 +1,1 @@
-git: "git://github.com/hannesm/xmpp.git#otr"
+git: "https://github.com/hannesm/xmpp.git#otr"

--- a/packages/jackline/jackline.0.1.0/url
+++ b/packages/jackline/jackline.0.1.0/url
@@ -1,1 +1,1 @@
-git: "git://github.com/hannesm/jackline.git"
+git: "https://github.com/hannesm/jackline.git"

--- a/packages/otr/otr.0.2.1/url
+++ b/packages/otr/otr.0.2.1/url
@@ -1,1 +1,1 @@
-git: "git://github.com/hannesm/ocaml-otr.git"
+git: "https://github.com/hannesm/ocaml-otr.git"

--- a/packages/ptime/ptime.0.0.1/url
+++ b/packages/ptime/ptime.0.0.1/url
@@ -1,1 +1,1 @@
-git: "http://erratique.ch/repos/ptime.git"
+git: "https://github.com/dbuenzli/ptime.git"


### PR DESCRIPTION
- replace urls with their https equivalents in `packages/*/*/url`
- add instructions on using this repo over https. Separately from this PR, jackline's [README](https://github.com/hannesm/jackline#installing-jackline) should also be reflected to show this.
